### PR TITLE
Stop storing definitions in lists

### DIFF
--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -3,14 +3,15 @@
 module Main where
 
 import           Control.Concurrent.STM
+import           Control.Lens
 import           Control.Monad.Trans.Reader
 import           Data.Aeson
 import           Data.Text
+import qualified Network.Wreq               as W
 import           Scalpel
 import           Templating
 import           Test.Hspec
 import           Text.Regex
-import qualified Network.Wreq                as W
 
 main :: IO ()
 main = hspec $ do
@@ -22,13 +23,19 @@ main = hspec $ do
   describe "reading results" $ do
     it "detects success" $ do
       r <- newTVarIO (Just "foo") :: IO (TVar TopicResult)
-      let req = WebhookRequest "x" W.defaults (object []) "foo"
+      let req = blank & requestEndpoint .~ "x"
+                      & requestOpts .~ W.defaults
+                      & requestParameters .~ object []
+                      & requestTopic .~ "foo"
           handler = doHandle req
       result <- runReaderT handler r
       result `shouldBe` True
     it "detects failures" $ do
       r <- newTVarIO (Just "bar") :: IO (TVar TopicResult)
-      let req = WebhookRequest "x" W.defaults (object []) "foo"
+      let req = blank & requestEndpoint .~ "x"
+                      & requestOpts .~ W.defaults
+                      & requestParameters .~ object []
+                      & requestTopic .~ "foo"
           handler = doHandle req
       result <- runReaderT handler r
       result `shouldBe` False


### PR DESCRIPTION
Before, we were storing API/webhook definitions in a list. This makes it much harder to re-use the results of one request in a subsequent test. This PR opens up the possibility of `create a contact, delete that contact` type chaining.
