### PR TITLE
Fix hackage warnings

### DIFF
--- a/scalpel.cabal
+++ b/scalpel.cabal
@@ -8,12 +8,18 @@ version:             0.1.0.0
 license:             Apache-2.0
 license-file:        LICENSE
 author:              Bob Long
+synopsis:            Test webhooks locally
+description:         Opinionated tool for QAing webhooks on remote services using ngrok
 maintainer:          robertjflong@gmail.com
 -- copyright:           
 category:            Web
 build-type:          Simple
 -- extra-source-files:  
 cabal-version:       >=1.10
+
+source-repository head
+  type: git
+  location: https://github.com/bobjflong/scalpel.git
 
 library
   exposed-modules:     Scalpel, Templating, IntercomDefinitions, Internal
@@ -55,6 +61,7 @@ executable scalpel
                        , transformers
                        , shelly
   hs-source-dirs:      src
+  default-language:    Haskell2010
 
 test-suite tests
   ghc-options:         -Wall

--- a/shell.nix
+++ b/shell.nix
@@ -12,13 +12,20 @@ let
         pname = "scalpel";
         version = "0.1.0.0";
         src = ./.;
+        isLibrary = true;
+        isExecutable = true;
         libraryHaskellDepends = [
+          aeson async base bytestring hastache lens lens-aeson rainbow random
+          shelly Spock stm text transformers wreq
+        ];
+        executableHaskellDepends = [
           aeson async base bytestring hastache lens lens-aeson rainbow random
           shelly Spock stm text transformers wreq
         ];
         testHaskellDepends = [
           aeson base hspec lens regex-compat stm text transformers wreq
         ];
+        description = "Test webhooks locally";
         license = stdenv.lib.licenses.asl20;
       };
 


### PR DESCRIPTION
fixing up the .cabal file so that hackage accepts it:

```
> cabal check
No errors or warnings could be found in the package.
```
