### PR TITLE
Support a command line argument to loop tests

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,6 +2,7 @@ module Main (
   main
 )  where
 
+import           Control.Concurrent
 import           Shelduck.IntercomDefinitions
 import           System.Environment
 
@@ -9,8 +10,14 @@ printUsage :: IO ()
 printUsage = mapM_ putStrLn usageLines
   where usageLines = ["USAGE: shelduck <definition_type>", "Current definition_types: intercom"]
 
+runIntercomDefinitionsFromCommandLine :: [String] -> IO ()
+runIntercomDefinitionsFromCommandLine intercomArgs =
+  case intercomArgs of
+    ("loop":_) -> runIntercomDefinitions >> threadDelay 1800000000 >> runIntercomDefinitionsFromCommandLine intercomArgs
+    _ -> runIntercomDefinitions
+
 main = do
   args <- getArgs
   case args of
-    ("intercom":_) -> runIntercomDefinitions
+    ("intercom":args) -> runIntercomDefinitionsFromCommandLine args
     _ -> printUsage


### PR DESCRIPTION
(reduces reliance on cron jobs, makes it easier to deploy)

eg. `shelduck intercom loop`
